### PR TITLE
Reaction api bug fix

### DIFF
--- a/src/add_reaction.py
+++ b/src/add_reaction.py
@@ -1,7 +1,7 @@
 import json
 import os
 import psycopg2
-from src.utils import get_cors_headers, verify_token
+from utils import get_cors_headers, verify_token
 
 def add_reaction_handler(event, context, db_connection=None):
     # Get CORS headers

--- a/src/create_session.py
+++ b/src/create_session.py
@@ -80,7 +80,7 @@ def create_session_handler(event, context, s3_client=None, db_connection=None):
         
         insert_guest_query = """
             INSERT INTO guests (guest_id, name, session_id, is_owner)
-            VALUES (%s, %s, %s)
+            VALUES (%s, %s, %s, %s)
             """
         
         cursor.execute(insert_session_query, (user_id, password, url, expires_at))

--- a/src/create_session.py
+++ b/src/create_session.py
@@ -79,14 +79,15 @@ def create_session_handler(event, context, s3_client=None, db_connection=None):
             """
         
         insert_guest_query = """
-            INSERT INTO guests (guest_id, name, session_id)
+            INSERT INTO guests (guest_id, name, session_id, is_owner)
             VALUES (%s, %s, %s)
             """
         
         cursor.execute(insert_session_query, (user_id, password, url, expires_at))
         session_id = cursor.fetchone()[0]
 
-        cursor.execute(insert_guest_query, (user_id, "Session Owner", session_id) )
+        guest_id = f'{user_id}|{session_id}'
+        cursor.execute(insert_guest_query, (guest_id, "Session Owner", session_id, True) )
 
         for i in range(num_images):
             photo_id = f'{url}-image-{str(i)}'

--- a/src/create_session.py
+++ b/src/create_session.py
@@ -78,8 +78,15 @@ def create_session_handler(event, context, s3_client=None, db_connection=None):
             RETURNING photo_id;
             """
         
+        insert_guest_query = """
+            INSERT INTO guests (guest_id, name, session_id)
+            VALUES (%s, %s, %s)
+            """
+        
         cursor.execute(insert_session_query, (user_id, password, url, expires_at))
         session_id = cursor.fetchone()[0]
+
+        cursor.execute(insert_guest_query, (user_id, "Session Owner", session_id) )
 
         for i in range(num_images):
             photo_id = f'{url}-image-{str(i)}'

--- a/src/remove_reaction.py
+++ b/src/remove_reaction.py
@@ -1,7 +1,7 @@
 import json
 import os
 import psycopg2
-from src.utils import get_cors_headers, verify_token
+from utils import get_cors_headers, verify_token
 
 def remove_reaction_handler(event, context, db_connection=None):
     # Get CORS headers

--- a/terraform/lambdas.tf
+++ b/terraform/lambdas.tf
@@ -110,7 +110,7 @@ resource "aws_lambda_function" "register_user" {
 resource "aws_lambda_function" "add_reaction" {
   function_name    = "photo-ranker-add-reaction-${terraform.workspace}"
   role             = aws_iam_role.lambda_role.arn
-  handler          = "src/add_reaction.add_reaction_handler"
+  handler          = "add_reaction.add_reaction_handler"
   runtime          = "python3.9"
   timeout          = 5
   filename         = "src.zip"
@@ -131,7 +131,7 @@ resource "aws_lambda_function" "add_reaction" {
 resource "aws_lambda_function" "remove_reaction" {
   function_name    = "photo-ranker-remove-reaction-${terraform.workspace}"
   role             = aws_iam_role.lambda_role.arn
-  handler          = "src/remove_reaction.remove_reaction_handler"
+  handler          = "remove_reaction.remove_reaction_handler"
   runtime          = "python3.9"
   timeout          = 5
   filename         = "src.zip"

--- a/test/integration_tests/conftest.py
+++ b/test/integration_tests/conftest.py
@@ -165,6 +165,7 @@ def db_connection(postgresql):
         	guest_id text primary key,
         	name text default 'guest',
         	session_id int not null,
+            is_owner BOOLEAN DEFAULT FALSE,
         	foreign key (session_id) references sessions(session_id) on delete cascade
         );
 


### PR DESCRIPTION
Adding session owners as guests of their own session in the DB so they can add reactions and comments. Their guestIds are the session owner user_id|session_id. This way they are always unique and they can be easily reconstructed for future queries.